### PR TITLE
Update info about 7.1 version.

### DIFF
--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -1,12 +1,14 @@
 ---
 isChild: true
-title:   使用当前稳定版本 (5.6)
+title:   使用当前稳定版本 (7.1)
 anchor:  use_the_current_stable_version
 ---
 
-## 使用当前稳定版本 (5.6) {#use_the_current_stable_version_title}
+## 使用当前稳定版本 (7.1) {#use_the_current_stable_version_title}
 
-如果你刚开始学习 PHP，请使用最新的稳定版本 [PHP 5.6][php-release]。PHP 近年来有了巨大的改进，增加了许多强大的 [新特性](#language_highlights)。虽然 5.2 和 5.6 之间增加的版本号似乎很小， 但它代表了 _重大的_ 改进。如果你想查找一个函数及其用法，可以去官方手册 [php.net][php-docs] 中查找。
+如果你刚开始学习 PHP，请使用最新的稳定版本 [PHP 7.1][php-release]。PHP 7.1 作为最新的版本，在旧的 5.x 版本上增加许多强大的[新特性](#language_highlights)。得益于引擎被大幅重写，现在 PHP 的速度比旧版本来得更加快速。
+
+在不久的将来，通常你会发现 PHP 5.x 仍在使用，且 5.x 的最新版本为 5.6。这不是一个坏选择，但你应该尽快尝试升级，到最新的稳定版本——因为 PHP 5.6 将在 2018 年后停止接收安全更新。升级 PHP 并不难，因为它没有打破很多的向后兼容性。如果你不确定某个函数或特性存在于哪个版本，可以去官方手册 [php.net][php-docs] 中查找。
 
 [php-release]: http://php.net/downloads.php
 [php-docs]: http://php.net/manual/

--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -7,7 +7,7 @@ anchor:  mac_setup
 ## Mac 安装 {#mac_setup_title}
 
 OS X 系统会预装 PHP， 只是一般情况下版本会比最新稳定版低一些。目前 Lion 是  5.3.10，
-Mavericks 是 5.4.17， Yosemite 则是 5.5.9， 但在 PHP 5.6 出来之后， 这些往往是不够的。
+Mavericks 是 5.4.17， Yosemite 是 5.5.9，El Capitan 是 5.5.29，Sierra 则是 5.6.24，但在 PHP 7.1 出来之后， 这些往往是不够的。
 
 这里有许多方式在 OS X 上安装 PHP 。
 
@@ -16,7 +16,7 @@ Mavericks 是 5.4.17， Yosemite 则是 5.5.9， 但在 PHP 5.6 出来之后， 
 [Homebrew] 是一个强大的 OS X 专用包管理器， 它可以帮助你轻松的安装 PHP 和各种扩展。
 [Homebrew PHP] 是一个包含与 PHP 相关的 Formulae，能让你通过 homebrew 安装 PHP 的仓库。
 
-也就是说, 你可以通过 `brew install` 命令安装 `php53`, `php54`, `php55` 或者 `php56` ，并且通过修改 `PATH` 变量来切换各个版本。或者你也可以使用 [brew-php-switcher][brew-php-switcher] 来自动切换。
+也就是说, 你可以通过 `brew install` 命令安装 `php53`，`php54`，`php55`，`php56`，`php70` 或者 `php71` ，并且通过修改 `PATH` 变量来切换各个版本。或者你也可以使用 [brew-php-switcher][brew-php-switcher] 来自动切换。
 
 ### 通过 Macports 安装 PHP
 
@@ -24,14 +24,14 @@ Mavericks 是 5.4.17， Yosemite 则是 5.5.9， 但在 PHP 5.6 出来之后， 
 
 MacPorts 支持预编译的二进制文件，因此你不必每次都重新从源码压缩包编译，如果你的系统没有安装这些包，它会节省你很多时间。
 
-此时，你可以通过 `port install` 命名来安装 `php53`，`php54`，`php55` 或者 `php56`，比如：
+此时，你可以通过 `port install` 命名来安装 `php53`，`php54`，`php55`，`php56`，`php70` 或者 `php71`，比如：
 
-    sudo port install php54
-    sudo port install php55
+    sudo port install php56
+    sudo port install php71
 
 你也可以执行 `select` 命令来切换当前的 php 版本：
 
-    sudo port select --set php php55
+    sudo port select --set php php71
 
 
 ### 通过 phpbrew 安装 PHP
@@ -39,7 +39,7 @@ MacPorts 支持预编译的二进制文件，因此你不必每次都重新从�
 [phpbrew] 是一个安装与管理多个 PHP 版本的工具。它在应用程序或者项目需要不同版本的 PHP 时非常有用，让你不再需要使用虚拟机来处理这些情况。
 
 ### 通过 Liip's binary installer 安装 PHP
-[php-osx.liip.ch] 是另一种流行的选择，它提供了从5.3到5.6版本的单行安装功能。
+[php-osx.liip.ch] 是另一种流行的选择，它提供了从 5.3 到 7.1 版本的单行安装功能。
 它并不会覆盖Apple集成的PHP文件，而是将其安装在了一个独立的目录中(/usr/local/php5)。
 
 ### 源码编译


### PR DESCRIPTION
Update the pages about current stable version of PHP. The latest PHP version is 7.1 as stated on phptherightway.com.